### PR TITLE
Update listings.json

### DIFF
--- a/.github/scripts/listings.json
+++ b/.github/scripts/listings.json
@@ -5680,7 +5680,7 @@
         "date_updated": 1723606058,
         "url": "https://www.databricks.com/company/careers/university-recruiting/data-scientist---new-grad-2025-start-6866554002",
         "company_name": "Databricks",
-        "title": "Data Scientist - New Grad (2025 Start)",
+        "title": "Data Scientist - New Grad (2025 Start) (Masters/PhD only)",
         "locations": [
             "Mountain View, CA"
         ],


### PR DESCRIPTION
In the description for the job opening, it specifies recent graduates for just Masters and PhD. Here is the quote from the description. "You will have graduated in December 2024 or Spring 2025 with a Master's or PhD degree in a quantitative field (e.g., Statistics, Math, Computer Science, Physics, Economics, Operational Research or Engineering) and are looking to start immediately."